### PR TITLE
Add files via upload

### DIFF
--- a/customdata/4th Place Amends/amend_critters.xml
+++ b/customdata/4th Place Amends/amend_critters.xml
@@ -21,6 +21,96 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.w3.org/2001/XMLSchema critters.xsd">
 	<metatypes>
 		<metatype>
+			<name>Elephant</name>
+			<walk>2/1/0</walk>
+			<run>4/0/0</run>
+		</metatype>
+		<metatype>
+			<name>Unicorn</name>
+			<walk>3/1/0</walk>
+			<run>9/0/0</run>
+		</metatype>
+		<metatype>
+			<name>Domestic Cat</name>
+			<walk>2/1/0</walk>
+			<run>6/0/0</run>
+		</metatype>
+		<metatype>
+			<name>Bastet (Domestic Cat)</name>
+			<walk>2/1/0</walk>
+			<run>6/0/0</run>
+		</metatype>
+		<metatype>
+			<name>Dog</name>
+			<walk>2/1/0</walk>
+			<run>6/0/0</run>
+		</metatype>
+		<metatype>
+			<name>Mongrel (Dog)</name>
+			<walk>2/1/0</walk>
+			<run>6/0/0</run>
+		</metatype>
+		<metatype>
+			<name>Cockroach</name>
+			<walk>2/1/0</walk>
+			<run>3/0/0</run>
+		</metatype>
+		<metatype>
+			<name>Digit (Cockroach)</name>
+			<walk>2/1/0</walk>
+			<run>3/0/0</run>
+		</metatype>
+		<metatype>
+			<name>Digit (Spider)</name>
+			<walk>2/1/0</walk>
+			<run>3/0/0</run>
+		</metatype>
+		<metatype>
+			<name>Spider</name>
+			<walk>2/1/0</walk>
+			<run>3/0/0</run>
+		</metatype>
+		<metatype>
+			<name>Eagle</name>
+			<walk>1/1/6</walk>
+			<run>2/0/14</run>
+		</metatype>
+		<metatype>
+			<name>Rook (Eagle)</name>
+			<walk>1/1/6</walk>
+			<run>2/0/14</run>
+		</metatype>
+		<metatype>
+			<name>Crow</name>
+			<walk>1/1/6</walk>
+			<run>2/0/12</run>
+		</metatype>
+		<metatype>
+			<name>Rook (Crow)</name>
+			<walk>1/1/6</walk>
+			<run>2/0/12</run>
+		</metatype>
+		<metatype>
+			<name>Thunderbird, Greater</name>
+			<walk>2/1/4</walk>
+			<run>4/0/8</run>
+		</metatype>
+		<metatype>
+			<name>Roc, Lesser</name>
+			<walk>1/1/4</walk>
+			<run>2/0/10</run>
+		</metatype>
+		<metatype>
+			<name>Phoenician Birds</name>
+			<walk>1/1/6</walk>
+			<run>2/0/12</run>
+		</metatype>
+		<metatype>
+			<name>Iridescent Owl</name>
+			<walk>1/1/6</walk>
+			<run>2/0/10</run>
+		</metatype>
+		<metatype>
 			<name>Raccoon</name>
 			<bodmin>2</bodmin>
 			<bodmax>3</bodmax>

--- a/customdata/4th Place Amends/amend_cyberware.xml
+++ b/customdata/4th Place Amends/amend_cyberware.xml
@@ -47,6 +47,17 @@
 	</grades>
 	<cyberwares>
 		<cyberware>
+			<name>Internal Router</name>
+			<rating>4</rating>
+			<ess>Rating * 0.2</ess>
+			<cost>Rating * 4000</cost>
+			<notes>All other cyberware installed in a user that has an Internal Router will appear as Wireless Off for as long as it functions, becoming untargetable by others.
+
+Internal Router may also grant +Rating extra Firewall to resist any Matrix or Resonance Actions of the user's choice targeting it.
+
+An implanted Commlink or Cyberdeck cannot benefit from an Internal Router.</notes>
+		</cyberware>
+		<cyberware>
 			<name>Wired Reflexes</name>
 			<ess amendoperation="replace">FixedValues(2,3,4)</ess>
 			<cost amendoperation="replace">FixedValues(50000,100000,150000)</cost>

--- a/customdata/4th Place Amends/custom_critters.xml
+++ b/customdata/4th Place Amends/custom_critters.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--This file is part of Chummer5a.
+
+    Chummer5a is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Chummer5a is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Chummer5a.  If not, see <http://www.gnu.org/licenses/>.
+
+    You can obtain the full source code for Chummer5a at
+    https://github.com/chummer5a/chummer5a
+-->
+<chummer xmlns="" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://www.w3.org/2001/XMLSchema critters.xsd">
+  <metatypes>
+<!-- Region Old SR4 Stuff -->
+<!-- Region Hazard Pay -->
+      <metatype>
+         <id>add81ba2-eb30-40d1-9814-67d052dcd7c1</id>
+         <name>Spellephant</name>
+         <category>Paranormal Critters</category>
+         <karma>0</karma>
+         <bodmin>14</bodmin>
+         <bodmax>17</bodmax>
+         <bodaug>21</bodaug>
+         <agimin>5</agimin>
+         <agimax>8</agimax>
+         <agiaug>12</agiaug>
+         <reamin>5</reamin>
+         <reamax>8</reamax>
+         <reaaug>12</reaaug>
+         <strmin>16</strmin>
+         <strmax>19</strmax>
+         <straug>23</straug>
+         <chamin>3</chamin>
+         <chamax>6</chamax>
+         <chaaug>10</chaaug>
+         <intmin>5</intmin>
+         <intmax>8</intmax>
+         <intaug>12</intaug>
+         <logmin>2</logmin>
+         <logmax>5</logmax>
+         <logaug>9</logaug>
+         <wilmin>5</wilmin>
+         <wilmax>8</wilmax>
+         <wilaug>12</wilaug>
+         <inimin>14</inimin>
+         <inimax>20</inimax>
+         <iniaug>28</iniaug>
+         <edgmin>3</edgmin>
+         <edgmax>6</edgmax>
+         <edgaug>6</edgaug>
+         <magmin>6</magmin>
+         <magmax>9</magmax>
+         <magaug>9</magaug>
+         <resmin>0</resmin>
+         <resmax>3</resmax>
+         <resaug>3</resaug>
+         <depmin>0</depmin>
+         <depmax>0</depmax>
+         <depaug>0</depaug>
+         <essmin>0</essmin>
+         <essmax>6</essmax>
+         <essaug>6</essaug>
+         <walk>2/1/0</walk>
+         <run>18/0/0</run>
+         <sprint>2/1/0</sprint>
+         <bonus>
+            <enabletab>
+               <name>critter</name>
+            </enabletab>
+            <reach>2</reach>
+         </bonus>
+         <powers>
+            <power select="Tusk: DV (STR+2)P, AP -2">Natural Weapon</power>
+            <power select="Low Frequency">Enhanced Senses</power>
+            <power rating="9">Armor</power>
+            <power>Movement</power>
+            <power>Pounce</power>
+            <power>Wall Walking</power>
+         </powers>
+         <skills>
+            <skill rating="5">Clubs</skill>
+            <skill rating="4">Perception</skill>
+            <skill rating="6">Running</skill>
+			<skill rating="4">Climbing</skill>
+            <skill rating="4">Unarmed Combat</skill>
+         </skills>
+         <source>4PR</source>
+         <page>HS 41</page>
+      </metatype>
+ <!-- End Region SOX -->
+  </metatypes>
+</chummer>

--- a/customdata/4th Place Amends/custom_weapons.xml
+++ b/customdata/4th Place Amends/custom_weapons.xml
@@ -416,6 +416,26 @@
   </accessories>
   <weapons>
     <weapon>
+      <id>9ce465b4-7127-4c48-ade3-7c23543e0893</id>
+      <name>Competition Pads</name>
+      <category>Unarmed</category>
+      <type>Melee</type>
+      <conceal>0</conceal>
+      <accuracy>Physical</accuracy>
+      <reach>0</reach>
+      <damage>({STR})S</damage>
+      <ap>-</ap>
+      <mode>0</mode>
+      <rc>0</rc>
+      <ammo>0</ammo>
+      <avail>2R</avail>
+      <cost>40</cost>
+      <source>4PR</source>
+      <page>1</page>
+      <useskill>Unarmed Combat</useskill>
+	   <notes>Deals damage equal to your Unarmed Attack, but always as Stun.</notes>
+    </weapon>
+    <weapon>
       <id>92e894d2-f769-4252-a07c-9ff2d8397b4e</id>
       <name>Kitsune Bite</name>
       <category>Unarmed</category>


### PR DESCRIPTION
new critter movement is
mundane elephants are now x2/x4
unicorns have been made comparable in speeds to horses at x3/x9

Domestic Cats and Dogs and technocritters based on them are now x2/x6
Spiders and Cockroaches and technocritters based on them are now x2/x3

anything which is a bird has had its flight speeds doubled and its ground speeds set to x1/x2 (this includes fixing the iridescent owl which had its flight speed set as its ground speed despite definitely being meant to fly)
except for thunderbirds, flying bird, which can still walk/run at x2/x4 with its dinosaur legs

and we also have the custom Spellephant, with an x2/x18 movespeed and Movement, Pounce and Wall Walking critter powers

Competition Pads melee weapon, 40 nuyen, has note saying it only deals stun.

Internal Router changes made