### PR TITLE
3E Cyberware, Burnout's Way Fixes

### DIFF
--- a/customdata/4th Place Amends/amend_bioware.xml
+++ b/customdata/4th Place Amends/amend_bioware.xml
@@ -125,6 +125,25 @@
       <name>Cerebellum Booster</name>
       <rating amendoperation="replace">3</rating>
     </bioware>
-
+    <bioware>
+      <name>Boosted Reflexes</name>
+      <category>Cultured</category>
+      <bannedgrades>
+        <grade>Used</grade>
+        <grade>Used (Adapsin)</grade>
+      </bannedgrades>
+      <ess>FixedValues(0.5,1.25,2.5)</ess>
+      <capacity>0</capacity>
+      <avail>FixedValues(8R,10R,12R)</avail>
+      <cost>FixedValues(10000,40000,90000)</cost>
+      <bonus>
+        <initiative precedence="0">FixedValues(0,1,2)</initiative>
+        <initiativepass precedence="0">FixedValues(1,1,2)</initiativepass>
+        <skillwire precedence="0">Rating * 2</skillwire>
+        <dodge>FixedValues(0,1,2)</dodge>
+      </bonus>
+      <minrating>1</minrating>
+      <rating>3</rating>
+    </bioware>
   </biowares>
 </chummer>

--- a/customdata/4th Place Amends/amend_bioware.xml
+++ b/customdata/4th Place Amends/amend_bioware.xml
@@ -142,6 +142,12 @@
         <skillwire precedence="0">Rating * 2</skillwire>
         <dodge>FixedValues(0,1,2)</dodge>
       </bonus>
+      <forbidden>
+        <oneof>
+          <cyberware>Control Rig</cyberware>
+          <cyberware>Active Control Rig</cyberware>
+        </oneof>
+      </forbidden>
       <minrating>1</minrating>
       <rating>3</rating>
     </bioware>

--- a/customdata/4th Place Amends/amend_cyberware.xml
+++ b/customdata/4th Place Amends/amend_cyberware.xml
@@ -58,9 +58,56 @@ Internal Router may also grant +Rating extra Firewall to resist any Matrix or Re
 An implanted Commlink or Cyberdeck cannot benefit from an Internal Router.</notes>
 		</cyberware>
 		<cyberware>
+		<name>Bone Lacing (Plastic)</name>
+		<forbidden>
+			<oneof>
+			<cyberwarecontains>Bone Lacing</cyberwarecontains>
+			<bioware>Bone Density Augmentation</bioware>
+			</oneof>
+		</forbidden>
+		</cyberware>
+		<cyberware>
+		<name>Bone Lacing (Aluminum)</name>
+		<forbidden>
+			<oneof>
+			<cyberwarecontains>Bone Lacing</cyberwarecontains>
+			<bioware>Bone Density Augmentation</bioware>
+			</oneof>
+		</forbidden>
+		</cyberware>
+		<cyberware>
+		<name>Bone Lacing (Titanium)</name>
+		<forbidden>
+			<oneof>
+			<cyberwarecontains>Bone Lacing</cyberwarecontains>
+			<bioware>Bone Density Augmentation</bioware>
+			</oneof>
+		</forbidden>
+		</cyberware>
+		<cyberware>
 			<name>Wired Reflexes</name>
 			<ess amendoperation="replace">FixedValues(2,3,4)</ess>
 			<cost amendoperation="replace">FixedValues(50000,100000,150000)</cost>
+		</cyberware>
+		<cyberware>
+			<name>Digigrade Legs</name>
+			<ess>0</ess>
+			<pairbonus>
+				<movementreplace>
+					<category>Ground</category>
+				<speed>run</speed>
+				<val>6</val>
+				</movementreplace>
+				<sprintbonus>
+					<category>Ground</category>
+				<val>100</val>
+				</sprintbonus>
+				<weaponaccuracy>
+				<name>Raptor Foot</name>
+				<value>1</value>
+				</weaponaccuracy>
+			</pairbonus>
+			<notes>Also adds +2 Strength to kicking attacks.</notes>
 		</cyberware>
 		<cyberware>
 			<name>Nanohive, Hard</name>

--- a/customdata/4th Place Amends/custom_armor.xml
+++ b/customdata/4th Place Amends/custom_armor.xml
@@ -242,17 +242,17 @@
             <name>AGI</name>
             <val>1</val>
           </specificattribute>
-		  <cyberlimbattributebonus>
-			<name>AGI</name>
-			<val>1</val>
+		      <cyberlimbattributebonus>
+            <name>AGI</name>
+            <val>1</val>
           </cyberlimbattributebonus>
           <specificattribute>
             <name>STR</name>
             <val>1</val>
           </specificattribute>
-		  <cyberlimbattributebonus>
-			<name>STR</name>
-			<val>1</val>
+          <cyberlimbattributebonus>
+            <name>STR</name>
+            <val>1</val>
           </cyberlimbattributebonus>
         </bonus>
         <source>4PR</source>
@@ -278,9 +278,9 @@
             <name>AGI</name>
             <val>1</val>
           </specificattribute>
-		  <cyberlimbattributebonus>
-			<name>AGI</name>
-			<val>1</val>
+          <cyberlimbattributebonus>
+            <name>AGI</name>
+            <val>1</val>
           </cyberlimbattributebonus>
           <specificattribute>
             <name>REA</name>
@@ -311,9 +311,9 @@
             <name>STR</name>
             <val>2</val>
           </specificattribute>
-		  <cyberlimbattributebonus>
-			<name>STR</name>
-			<val>2</val>
+          <cyberlimbattributebonus>
+            <name>STR</name>
+            <val>2</val>
           </cyberlimbattributebonus>
         </bonus>
         <source>4PR</source>
@@ -337,12 +337,20 @@
         </gears>
         <bonus>
           <specificattribute>
-            <name>STR</name>
-            <val>2</val>
+            <name>AGI</name>
+            <val>1</val>
           </specificattribute>
-		  <cyberlimbattributebonus>
-			<name>STR</name>
-			<val>2</val>
+		      <cyberlimbattributebonus>
+            <name>AGI</name>
+            <val>1</val>
+          </cyberlimbattributebonus>
+          <specificattribute>
+            <name>STR</name>
+            <val>1</val>
+          </specificattribute>
+          <cyberlimbattributebonus>
+            <name>STR</name>
+            <val>1</val>
           </cyberlimbattributebonus>
         </bonus>
         <source>4PR</source>
@@ -524,6 +532,23 @@
       <armorcapacity>[0]</armorcapacity>
       <avail>0</avail>
       <cost>0</cost>
+			<bonus>
+				<movementreplace>
+					<category>Fly</category>
+					<speed>walk</speed>
+					<val>2</val>
+				</movementreplace>
+				<movementreplace>
+					<category>Fly</category>
+					<speed>run</speed>
+					<val>8</val>
+				</movementreplace>
+				<movementreplace>
+					<category>Fly</category>
+					<speed>sprint</speed>
+					<val>300</val>
+				</movementreplace>
+			</bonus>
       <source>4PR</source>
       <page>1</page>
       <notes>Identical effects to Cyberwings. Flight speed is x2/x8/+3.</notes>

--- a/customdata/4th Place Amends/custom_cyberware.xml
+++ b/customdata/4th Place Amends/custom_cyberware.xml
@@ -992,11 +992,11 @@
 			<bonus>
 				<spellresistance>Rating</spellresistance>
 			</bonus>
-			<requires>
+			<required>
 				<oneof>
 					<cyberware>Dermal Plating</cyberware>
 				</oneof>
-			</requires>
+			</required>
 			<rating>6</rating>
 			<notes>Grey Mana Dermal Plating's rating and grade must match your Dermal Plating rating and grade.</notes>
 		</cyberware>
@@ -1013,13 +1013,11 @@
 			<bonus>
 				<spellresistance>Rating</spellresistance>
 			</bonus>
-			<requires>
+			<required>
 				<oneof>
-					<cyberware>Bone Lacing (Plastic)</cyberware>
-					<cyberware>Bone Lacing (Aluminum)</cyberware>
-					<cyberware>Bone Lacing (Titanium)</cyberware>
+					<cyberwarecontains>Bone Lacing</cyberwarecontains>
 				</oneof>
-			</requires>
+			</required>
 			<notes>Subtracts 1 hit from any Health, mana-based Illusion, or mental Manipulation spells that affect the character. Bare-handed unarmed attacks ignore ItNW. Must be of identical grade to the character's Bone Lacing.</notes>
 		</cyberware>
 		<cyberware>
@@ -1332,11 +1330,207 @@
 			<source>4PR</source>
 			<page>1</page>
 			<bonus>
-				<unarmedap>-Rating</unarmedap>
+				<weaponcategoryap>
+					<name>Unarmed</name>
+					<bonus>Rating</bonus>
+				</weaponcategoryap>
+				<weaponcategoryap>
+					<name>Blades</name>
+					<bonus>Rating</bonus>
+				</weaponcategoryap>
+				<weaponcategoryap>
+					<name>Clubs</name>
+					<bonus>Rating</bonus>
+				</weaponcategoryap>
 			</bonus>
 			<forcegrade>None</forcegrade>
 			<rating>3</rating>
-			<notes>The AP bonus actually applies to all melee attacks, but chummer doesn't support doing so.</notes>
+			<notes>-Rating to AP.</notes>
+		</cyberware>
+		<cyberware>
+			<id>3e642a97-5da2-4664-bd6a-28633ea22bf3</id>
+			<name>Eye Laser System</name>
+			<limit>False</limit>
+			<category>Eyeware</category>
+			<ess>0</ess>
+			<capacity>[4]</capacity>
+			<avail>6</avail>
+			<cost>6000</cost>
+			<source>4PR</source>
+			<page>1</page>
+			<notes>Acts as a laser rangefinder and laser microphone. Can be used to transmit to other eye laser systems via eye contact. Can blind targets using the DEW skill.</notes>
+			<requireparent />
+		</cyberware>
+		<cyberware>
+			<id>90ecd22a-2403-47da-92c4-8a99ae0b8dba</id>
+			<name>Smartlink (Throwback)</name>
+			<category>Bodyware</category>
+			<ess>FixedValues(0.2,0.3,0.4,0.5)</ess>
+			<capacity>0</capacity>
+			<avail>8R</avail>
+			<cost>5000</cost>
+			<source>4PR</source>
+			<page>1</page>
+			<bonus>
+				<smartlink>2</smartlink>
+			</bonus>
+			<minrating>1</minrating>
+			<rating>4</rating>
+			<notes>Provides the Smartlink wireless bonus of +2 dice even when wireless off. Base Essence cost is 0.5, -0.1 Essence for each of the following: Simrig, Image Link, and Induction Pad or Skinlink Echo.</notes>
+		</cyberware>
+		<cyberware>
+			<id>2c83b652-68f5-4071-ad2a-026e1fd0cf6c</id>
+			<name>Smartlink-2 Upgrade</name>
+			<category>Bodyware</category>
+			<ess>0</ess>
+			<capacity>0</capacity>
+			<avail>16R</avail>
+			<cost>15000</cost>
+			<required>
+				<allof>
+				<cyberware>Smartlink (Throwback)</cyberware>
+				</allof>
+			</required>
+			<source>4PR</source>
+			<page>1</page>
+			<notes>Halves called shot penalties (does not stack with Sharpshooter/Strive for Perfection). -1 Threshold for grenade/rocket attacks. Must be of the same grade as the Throwback Smartlink.</notes>
+		</cyberware>
+		<cyberware>
+		<id>91601bc8-04f0-4883-9698-82a3504385d2</id>
+		<name>Bone Lacing (Kevlar)</name>
+		<category>Bodyware</category>
+		<ess>0.6</ess>
+		<capacity>0</capacity>
+		<avail>10</avail>
+		<cost>15000</cost>
+		<source>4PR</source>
+		<page>1</page>
+		<bonus>
+			<armor>2</armor>
+			<damageresistance>1</damageresistance>
+		</bonus>
+		<forbidden>
+			<oneof>
+			<cyberwarecontains>Bone Lacing</cyberwarecontains>
+			<bioware>Bone Density Augmentation</bioware>
+			</oneof>
+		</forbidden>
+		<notes>Kevlar Bone Lacing does not show up on cyberware scanners.</notes>
+		</cyberware>
+		<cyberware>
+		<id>dcd4e4e3-a868-4210-80fe-b48715cb905a</id>
+		<name>Bone Lacing (Ceramic)</name>
+		<category>Bodyware</category>
+		<ess>0.75</ess>
+		<capacity>0</capacity>
+		<avail>10</avail>
+		<cost>15000</cost>
+		<source>4PR</source>
+		<page>1</page>
+		<bonus>
+			<armor>1</armor>
+			<damageresistance>2</damageresistance>
+			<unarmeddv>1</unarmeddv>
+			<unarmeddvphysical />
+		</bonus>
+		<forbidden>
+			<oneof>
+			<cyberwarecontains>Bone Lacing</cyberwarecontains>
+			<bioware>Bone Density Augmentation</bioware>
+			</oneof>
+		</forbidden>
+		<notes>Ceramic Bone Lacing does not show up on cyberware scanners.</notes>
+		</cyberware>
+			<cyberware>
+			<id>26381bb5-2755-4841-b8a3-5152d5c53e74</id>
+			<name>Smartlink Induction Pad</name>
+			<limit>{arm}</limit>
+			<category>Cyberlimb Enhancement</category>
+			<ess>0.1</ess>
+			<capacity>[1]</capacity>
+			<avail>8R</avail>
+			<cost>1000</cost>
+			<source>4PR</source>
+			<page>1</page>
+			<blocksmounts>wrist,elbow,shoulder</blocksmounts>
+			<selectside />
+			<required>
+				<allof>
+				<cyberware>Smartlink (Throwback)</cyberware>
+				<parentdetails>
+				<OR>
+					<NONE />
+					<name operation="contains">Full Arm</name>
+					<name operation="contains">Lower Arm</name>
+					<name operation="contains">Hand</name>
+					<name operation="contains">Drone Arm</name>
+				</OR>
+				</parentdetails>
+				</allof>
+			</required>
+			<notes>At least one is required to use the Throwback Smartlink. The Throwback Smartlink comes with one by default. Installing the default induction pad into a cyberlimb reduces the smartlink essence cost by 0.1.</notes>
+		</cyberware>
+		<cyberware>
+			<id>09b447b8-b6c7-42a6-a85a-0843d84c95fe</id>
+			<name>Integrity Enhancement</name>
+			<limit>False</limit>
+			<category>Cyberlimb Enhancement</category>
+			<ess>0</ess>
+			<capacity>[Rating]</capacity>
+			<avail>10</avail>
+			<cost>Rating * 3000</cost>
+			<source>4PR</source>
+			<page>1</page>
+			<notes>Adds +Rating damage resistance against called shots which target the limb. Torso/Head Integrity Enhancement applies against CS: Vitals as well.</notes>
+			<rating>3</rating>
+			<requireparent />
+		</cyberware>
+		<cyberware>
+			<id>41771118-3fd6-46ed-bea3-5e932ae292f4</id>
+			<name>Move-by-Wire System (Throwback)</name>
+			<category>Bodyware</category>
+			<ess>FixedValues(5,7)</ess>
+			<capacity>0</capacity>
+			<avail>FixedValues(24F,36F)</avail>
+			<cost>Rating * 250000</cost>
+			<source>4PR</source>
+			<page>1</page>
+			<bonus>
+				<initiative precedence="0">FixedValues(9,12)</initiative>
+				<initiativepass precedence="0">Rating</initiativepass>
+				<dodge>Rating</dodge>
+				<specificattribute>
+					<name>REA</name>
+					<val>FixedValues(4,6)</val>
+					<aug>FixedValues(0,2)</aug>
+				</specificattribute>
+				<skilllinkedattribute>
+					<name>AGI</name>
+					<bonus>Rating</bonus>
+				</skilllinkedattribute>
+				<skilllinkedattribute>
+					<name>REA</name>
+					<bonus>Rating</bonus>
+				</skilllinkedattribute>
+				<skilllinkedattribute>
+					<name>CHA</name>
+					<bonus>FixedValues(-3,-4)</bonus>
+				</skilllinkedattribute>
+				<sociallimit>FixedValues(-3,-4)</sociallimit>
+			</bonus>
+			<minrating>1</minrating>
+			<rating>2</rating>
+			<notes>
+				Uses (Rating + 2) Monthly Focus points for medical care. If the character lacks enough focus points, it costs 10,000 nuyen per missing point per month.
+
+				Taking (4-Rating) or more boxes of physical damage in a stressful situation requires a WIL test, threshold (Rating * 2). Failure causes seizures.
+
+				Seizures deal 3P + 3S damage. Both are resisted by Body only. R4+ Throwback MBW will immediately cause the character to go into seizures.
+
+				At the end of each run, make a WIL test, threshold (Rating * 2). Failure means the character gains the TLE-X negative quality.
+
+				Overrides all other initiative and reaction enhancements which do not explicitly stack with other init/reaction enhancements.
+			</notes>
 		</cyberware>
 	</cyberwares>
 </chummer>

--- a/customdata/4th Place Amends/custom_cyberware.xml
+++ b/customdata/4th Place Amends/custom_cyberware.xml
@@ -1385,7 +1385,7 @@
 			<ess>0</ess>
 			<capacity>0</capacity>
 			<avail>16R</avail>
-			<cost>15000</cost>
+			<cost>25000</cost>
 			<required>
 				<allof>
 				<cyberware>Smartlink (Throwback)</cyberware>

--- a/customdata/4th Place Amends/custom_powers.xml
+++ b/customdata/4th Place Amends/custom_powers.xml
@@ -63,6 +63,62 @@
       </notes>
     </power>
     <power>
+      <id>9658890c-554b-43f4-983d-fec703e3eef4</id>
+      <name>Improved STR (Magic and Machine)</name>
+      <points>1</points>
+      <levels>True</levels>
+      <limit>1</limit>
+      <source>4PR</source>
+      <page>1</page>
+      <adeptway>0.5</adeptway>
+      <adeptwayrequires>
+      </adeptwayrequires>
+      <bonus>
+        <specificattribute>
+          <name>STR</name>
+          <val>Rating</val>
+        </specificattribute>
+        <cyberlimbattributebonus>
+          <name>STR</name>
+          <val>Rating</val>
+        </cyberlimbattributebonus>
+      </bonus>
+      <notes>
+      Magic and Machine's Improved Physical Attribute (STR) also improves cyberlimbs.
+      </notes>
+      <required>
+        <metamagic>Magic and Machine</metamagic>
+      </required>
+    </power>
+    <power>
+      <id>35a8a495-3718-418a-bb5c-27ff0deb9afd</id>
+      <name>Improved AGI (Magic and Machine)</name>
+      <points>1</points>
+      <levels>True</levels>
+      <limit>1</limit>
+      <source>4PR</source>
+      <page>1</page>
+      <adeptway>0.5</adeptway>
+      <adeptwayrequires>
+      </adeptwayrequires>
+      <bonus>
+        <specificattribute>
+          <name>AGI</name>
+          <val>Rating</val>
+        </specificattribute>
+        <cyberlimbattributebonus>
+          <name>AGI</name>
+          <val>Rating</val>
+        </cyberlimbattributebonus>
+      </bonus>
+      <notes>
+      Magic and Machine's Improved Physical Attribute (AGI) also improves cyberlimbs.
+      </notes>
+      <required>
+        <metamagic>Magic and Machine</metamagic>
+      </required>
+    </power>
+    <power>
       <id>a6306904-4615-4692-b079-eb418fefc928</id>
       <name>Improved Ability (Skill Group)</name>
       <points>1</points>


### PR DESCRIPTION
* Adds Burnout's Way Improved STR and AGI variants to boost cyberlimbs.
* Fixes SOLDIER Vulture to give the correct attribute bonuses.
* Adds 3E cyberware and bioware.