### PR TITLE
Update custom_qualities.xml

### DIFF
--- a/customdata/4th Place Amends/custom_qualities.xml
+++ b/customdata/4th Place Amends/custom_qualities.xml
@@ -1282,6 +1282,14 @@
 			<karma>5</karma>
 			<category>Positive</category>
 			<chargenonly />
+				<bonus>
+				<addware>
+					<name>Essence Antihole</name>
+					<rating>40</rating>
+					<grade>None</grade>
+					<type>Cyberware</type>
+				</addware>
+				</bonus>
 			<forbidden>
 				<oneof>
 					<quality>Designer Baby</quality>


### PR DESCRIPTION
It's a kludge, but it makes Gifted Genetics give a 0.4 Essence Antihole to spend on the desired genemod (that being the max cost of the ones available), so the quality at least functions, rather than requiring user monkeying