### PR TITLE
SFW-30 and Walther Battle Sword fixes

### DIFF
--- a/customdata/4th Place Amends/amend_weapons.xml
+++ b/customdata/4th Place Amends/amend_weapons.xml
@@ -508,6 +508,7 @@
 		</weapon>
 		<weapon>
 			<name>Walther Battle Sword</name>
+			<reach>2</reach>
 			<conceal>10</conceal>
 		</weapon>
 		<weapon>
@@ -864,6 +865,15 @@
       		<fullburst>15</fullburst>
       		<suppressive>40</suppressive>
 			<notes>Requires a Simple action to spin up before firing. When spun up, -6 to dice and Limit for sneaking tests, and +2 to audio detection.</notes>
+		</weapon>
+		<weapon>
+		    <name>Ruhrmetall SFW-30</name>
+			<mode>BF</mode>
+			<accuracy>6</accuracy>
+		</weapon>
+		<weapon>
+		    <name>Ruhrmetall SFW-30 Tracker Weapon</name>
+			<mode>SS</mode>
 		</weapon>
 	</weapons>
 </chummer>


### PR DESCRIPTION
the Walther Battle Sword is now Reach 2, the SFW-30 is now BF-only.