### PR TITLE
Bugfixes to drones and weapons

### DIFF
--- a/customdata/4th Place Amends/amend_vehicles.xml
+++ b/customdata/4th Place Amends/amend_vehicles.xml
@@ -199,11 +199,6 @@
 		  <armor>14</armor>
 		</vehicle>
 		<vehicle>
-			<id>bc21264d-527c-4066-b8c6-0aa24cff61cb</id>
-		  <name>Mitsuhama Malakim (Large)</name>
-		  <armor>14</armor>
-		</vehicle>
-		<vehicle>
 		  <id>73b7729b-89c1-44fb-950c-f8391376a6b8</id>
 		  <name>F-B Bumblebee</name>
 		  <armor>9</armor>

--- a/customdata/4th Place Amends/custom_weapons.xml
+++ b/customdata/4th Place Amends/custom_weapons.xml
@@ -1599,7 +1599,6 @@
         </accessory>
       </accessories>
       <accessorymounts>
-        <mount>Barrel</mount>
         <mount>Top</mount>
         <mount>Stock</mount>
         <mount>Side</mount>
@@ -3172,4 +3171,5 @@
     </weapon>
   </weapons>
 </chummer>
+
 

--- a/customdata/4th Place Amends/custom_weapons.xml
+++ b/customdata/4th Place Amends/custom_weapons.xml
@@ -1604,7 +1604,6 @@
         <mount>Stock</mount>
         <mount>Side</mount>
       </accessorymounts>
-      <weapontype>hipower</weapontype>
     </weapon>
     <weapon>
       <id>2c4c9736-c37a-4982-bc1d-d27eae255e0d</id>

--- a/customdata/4th Place Amends/custom_weapons.xml
+++ b/customdata/4th Place Amends/custom_weapons.xml
@@ -24,7 +24,7 @@
       <name>Original</name>
       <mount />
       <avail>+10</avail>
-      <cost>Weapon Cost * 9</cost>
+      <cost>Weapon Cost * 4.5</cost>
       <source>4PR</source>
       <page>1</page>
       <rating>0</rating>
@@ -40,7 +40,7 @@
       <name>Original (Melee)</name>
       <mount />
       <avail>+10</avail>
-      <cost>Weapon Cost * 9</cost>
+      <cost>Weapon Cost * 4.5</cost>
       <source>4PR</source>
       <page>1</page>
       <damage>-1</damage>
@@ -1799,7 +1799,7 @@
       <name>AN-74</name>
       <category>Assault Rifles</category>
       <type>Ranged</type>
-      <conceal>5</conceal>
+      <conceal>6</conceal>
       <accuracy>6</accuracy>
       <reach>0</reach>
       <damage>10P</damage>
@@ -1945,6 +1945,7 @@
       <source>4PR</source>
       <page>1</page>
       <spec>Swords</spec>
+      <hide />
     </weapon>
     <weapon>
       <id>72892ff5-0572-4ed0-9aef-803ae2b80c21</id>
@@ -1997,6 +1998,7 @@
       <source>4PR</source>
       <page>1</page>
       <spec>Batons</spec>
+      <hide />
     </weapon>
     <weapon>
       <id>7ec654b0-f448-4ebc-b6de-99e0995acd5c</id>


### PR DESCRIPTION
* The Original weapon mod is set to cost 4.5x the weapon price rather than 9x, as Vintage doubles the cost of weapon mods.
* The Ares Bravo/Sierra melee weapons shouldn't show up as purchaseable.
* The AN-74 is now Conceal +6 as intended.
* Deleted a duplicate of the Malakim amend entry as cleanup.