### PR TITLE
Lightning Reflexes and REA stacking fix

### DIFF
--- a/customdata/4th Place Amends/amend_bioware.xml
+++ b/customdata/4th Place Amends/amend_bioware.xml
@@ -110,8 +110,19 @@
     <bioware>
       <name>Synaptic Booster</name>
       <bonus>
-	<disablequality amendoperation="remove">3564b678-7721-4a8d-ac79-1600cf92dc14</disablequality>
-	<initiativepass amendoperation="replace">Rating</initiativepass>
+        <initiativepass precedence="0">Rating</initiativepass>
+        <specificattribute>
+          <name>REA</name>
+          <val>Rating</val>
+        </specificattribute>
+      </bonus>
+    </bioware>
+    <bioware>
+      <name>Synaptic Acceleration</name>
+      <bonus>
+        <dodge>1</dodge>
+        <initiative precedence="0">1</initiative>
+        <initiativepass precedence="0">1</initiativepass>
       </bonus>
     </bioware>
     <bioware>
@@ -151,10 +162,11 @@
       <minrating>1</minrating>
       <rating>3</rating>
     </bioware>
-	<bioware>
+
+    <bioware>
       <name>Qualia</name>
-      <ess amendoperation="replace">0.1</ess>
-      <bonus amendoperation="replace">
+      <ess>0.1</ess>
+      <bonus>
         <skilllinkedattribute>
           <name>INT</name>
           <bonus>1</bonus>

--- a/customdata/4th Place Amends/amend_bioware.xml
+++ b/customdata/4th Place Amends/amend_bioware.xml
@@ -109,7 +109,7 @@
     </bioware>
     <bioware>
       <name>Synaptic Booster</name>
-      <bonus>
+      <bonus amendoperation="replace">
         <initiativepass precedence="0">Rating</initiativepass>
         <specificattribute>
           <name>REA</name>
@@ -119,7 +119,7 @@
     </bioware>
     <bioware>
       <name>Synaptic Acceleration</name>
-      <bonus>
+      <bonus amendoperation="replace">
         <dodge>1</dodge>
         <initiative precedence="0">1</initiative>
         <initiativepass precedence="0">1</initiativepass>
@@ -162,11 +162,10 @@
       <minrating>1</minrating>
       <rating>3</rating>
     </bioware>
-
     <bioware>
       <name>Qualia</name>
       <ess>0.1</ess>
-      <bonus>
+      <bonus amendoperation="replace">
         <skilllinkedattribute>
           <name>INT</name>
           <bonus>1</bonus>

--- a/customdata/4th Place Amends/amend_cyberware.xml
+++ b/customdata/4th Place Amends/amend_cyberware.xml
@@ -86,25 +86,18 @@ An implanted Commlink or Cyberdeck cannot benefit from an Internal Router.</note
 		</cyberware>
 		<cyberware>
 			<name>Reaction Enhancers</name>
-			<bonus>
+			<bonus amendoperation="replace">
 				<specificattribute precedence="0">
 				<name>REA</name>
 				<val>Rating</val>
 				</specificattribute>
 			</bonus>
-			<wirelesspairbonus mode="replace">
-				<specificattribute precedence="1">
-				<name>REA</name>
-				<val>Rating</val>
-				<aug>FixedValues(0,1,2)</aug>
-				</specificattribute>
-			</wirelesspairbonus>
 		</cyberware>
 		<cyberware>
 			<name>Wired Reflexes</name>
 			<ess amendoperation="replace">FixedValues(2,3,4)</ess>
 			<cost amendoperation="replace">FixedValues(50000,100000,150000)</cost>
-			<bonus>
+			<bonus amendoperation="replace">
 				<initiativepass precedence="0">Rating</initiativepass>
 				<specificattribute>
 				<name>REA</name>
@@ -114,7 +107,7 @@ An implanted Commlink or Cyberdeck cannot benefit from an Internal Router.</note
 		</cyberware>
 		<cyberware>
 		<name>Move-by-Wire System</name>
-		<bonus>
+		<bonus amendoperation="replace">
 			<initiative precedence="0">FixedValues(3,6,9)</initiative>
 			<initiativepass precedence="0">FixedValues(0,1,1)</initiativepass>
 			<skillwire precedence="0">Rating * 2</skillwire>

--- a/customdata/4th Place Amends/amend_cyberware.xml
+++ b/customdata/4th Place Amends/amend_cyberware.xml
@@ -85,9 +85,47 @@ An implanted Commlink or Cyberdeck cannot benefit from an Internal Router.</note
 		</forbidden>
 		</cyberware>
 		<cyberware>
+			<name>Reaction Enhancers</name>
+			<bonus>
+				<specificattribute precedence="0">
+				<name>REA</name>
+				<val>Rating</val>
+				</specificattribute>
+			</bonus>
+			<wirelesspairbonus mode="replace">
+				<specificattribute precedence="1">
+				<name>REA</name>
+				<val>Rating</val>
+				<aug>FixedValues(0,1,2)</aug>
+				</specificattribute>
+			</wirelesspairbonus>
+		</cyberware>
+		<cyberware>
 			<name>Wired Reflexes</name>
 			<ess amendoperation="replace">FixedValues(2,3,4)</ess>
 			<cost amendoperation="replace">FixedValues(50000,100000,150000)</cost>
+			<bonus>
+				<initiativepass precedence="0">Rating</initiativepass>
+				<specificattribute>
+				<name>REA</name>
+				<val>Rating</val>
+				</specificattribute>
+			</bonus>
+		</cyberware>
+		<cyberware>
+		<name>Move-by-Wire System</name>
+		<bonus>
+			<initiative precedence="0">FixedValues(3,6,9)</initiative>
+			<initiativepass precedence="0">FixedValues(0,1,1)</initiativepass>
+			<skillwire precedence="0">Rating * 2</skillwire>
+			<sociallimit>-Rating</sociallimit>
+			<specificattribute>
+			<name>REA</name>
+			<val>Rating</val>
+			</specificattribute>
+		</bonus>
+		<minrating>1</minrating>
+		<rating>3</rating>
 		</cyberware>
 		<cyberware>
 			<name>Digigrade Legs</name>

--- a/customdata/4th Place Amends/amend_powers.xml
+++ b/customdata/4th Place Amends/amend_powers.xml
@@ -62,7 +62,7 @@
 			<points>0.5</points>
 			<adeptway>0.25</adeptway>
 			<adeptwayrequires>
-				<required>
+				<required amendoperation="replace">
 				<oneof>
 					<quality>The Burnout's Way</quality>
 					<quality>The Spiritual's Way</quality>
@@ -79,7 +79,7 @@
 			<points>1</points>
 			<adeptway>0.5</adeptway>
 			<adeptwayrequires>
-				<required>
+				<required amendoperation="replace">
 				<oneof>
 					<quality>The Warrior's Way</quality>
 					<quality>The Spiritual's Way</quality>
@@ -116,7 +116,7 @@
 			<points>0.5</points>
 			<adeptway>0.25</adeptway>
 			<adeptwayrequires>
-				<required>
+				<required amendoperation="replace">
 				<oneof>
 					<quality>The Athlete's Way</quality>
 					<quality>The Burnout's Way</quality>
@@ -166,7 +166,7 @@
 			<page>4</page>
 			<adeptway>0.25</adeptway>
 		    <adeptwayrequires>
-				<required>
+				<required amendoperation="replace">
 					<oneof>
 						<quality>The Speaker's Way</quality>
 						<quality>The Spiritual Way</quality>
@@ -177,7 +177,7 @@
 		<power>
 			<name>Improved Physical Attribute</name>
 			<adeptwayrequires>
-				<required>
+				<required amendoperation="replace">
 				<oneof>
 					<quality>The Athlete's Way</quality>
 					<quality>The Warrior's Way</quality>
@@ -189,7 +189,7 @@
 		<power>
 			<name>Improved Ability (skill)</name>
 		    <adeptwayrequires>
-				<required>
+				<required amendoperation="replace">
 					<oneof>
 						<quality>The Artisan's Way</quality>
 						<quality>The Artist's Way</quality>
@@ -205,7 +205,7 @@
 		<power>
 			<name>Smashing Blow</name>
 		    <adeptwayrequires>
-				<required>
+				<required amendoperation="replace">
 					<oneof>
 						<quality>The Burnout's Way</quality>
 						<quality>The Spiritual Way</quality>
@@ -216,7 +216,7 @@
 		<power>
 			<name>Spell Resistance</name>
 		    <adeptwayrequires>
-				<required>
+				<required amendoperation="replace">
 					<oneof>
 						<quality>The Burnout's Way</quality>
 						<quality>The Spiritual Way</quality>
@@ -227,7 +227,7 @@
 		<power>
 			<name>Supernatural Toughness</name>
 		    <adeptwayrequires>
-				<required>
+				<required amendoperation="replace">
 					<oneof>
 						<quality>The Burnout's Way</quality>
 						<quality>The Spiritual Way</quality>
@@ -239,7 +239,7 @@
 		<power>
 			<name>Traceless Walk</name>
 		    <adeptwayrequires>
-				<required>
+				<required amendoperation="replace">
 					<oneof>
 						<quality>The Beast's Way</quality>
 						<quality>The Burnout's Way</quality>
@@ -252,7 +252,7 @@
 		<power>
 			<name>Transmit Damage</name>
 		    <adeptwayrequires>
-				<required>
+				<required amendoperation="replace">
 					<oneof>
 						<quality>The Burnout's Way</quality>
 						<quality>The Spiritual Way</quality>
@@ -263,7 +263,7 @@
 		<power>
 			<name>Wall Running</name>
 		    <adeptwayrequires>
-				<required>
+				<required amendoperation="replace">
 					<oneof>
 						<quality>The Ahtlete's Way</quality>
 						<quality>The Burnout's Way</quality>
@@ -276,7 +276,7 @@
 		<power>
 			<name>State of Purity</name>
 			<adeptwayrequires>
-				<required>
+				<required amendoperation="replace">
 				<oneof>
 					<quality>The Warrior's Way</quality>
 					<quality>The Spiritual's Way</quality>

--- a/customdata/4th Place Amends/custom_bioware.xml
+++ b/customdata/4th Place Amends/custom_bioware.xml
@@ -225,14 +225,6 @@
 					<bonus>2</bonus>
 				</specificskill>
 			</bonus>
-			<forbidden>
-				<oneof>
-					<bioware>Synaptic Booster</bioware>
-					<cyberware>Wired Reflexes</cyberware>
-					<cyberware>Reaction Enhancers</cyberware>
-					<cyberware>Move-by-Wire System</cyberware>
-				</oneof>
-			</forbidden>
 			<notes>Manually add the relevant metagenetic negative quality by taking one of the SURGE qualities for free, adding the negative quality, and then removing the SURGE quality.</notes>
 			<forcegrade>None</forcegrade>
 			<source>4PR</source>


### PR DESCRIPTION
Most ware is changed so it no longer suppresses Lightning Reflexes, and REA granted by augmentations now fully stacks.