### PR TITLE
Catlike Reflexes fix

### DIFF
--- a/customdata/4th Place Amends/amend_bioware.xml
+++ b/customdata/4th Place Amends/amend_bioware.xml
@@ -115,6 +115,7 @@
           <name>REA</name>
           <val>Rating</val>
         </specificattribute>
+        <disablequality>Catlike Reflexes</disablequality>
       </bonus>
     </bioware>
     <bioware>

--- a/customdata/4th Place Amends/amend_cyberware.xml
+++ b/customdata/4th Place Amends/amend_cyberware.xml
@@ -87,10 +87,11 @@ An implanted Commlink or Cyberdeck cannot benefit from an Internal Router.</note
 		<cyberware>
 			<name>Reaction Enhancers</name>
 			<bonus amendoperation="replace">
-				<specificattribute precedence="0">
-				<name>REA</name>
-				<val>Rating</val>
+				<specificattribute>
+					<name>REA</name>
+					<val>Rating</val>
 				</specificattribute>
+				<disablequality>Catlike Reflexes</disablequality>
 			</bonus>
 		</cyberware>
 		<cyberware>
@@ -100,9 +101,10 @@ An implanted Commlink or Cyberdeck cannot benefit from an Internal Router.</note
 			<bonus amendoperation="replace">
 				<initiativepass precedence="0">Rating</initiativepass>
 				<specificattribute>
-				<name>REA</name>
-				<val>Rating</val>
+					<name>REA</name>
+					<val>Rating</val>
 				</specificattribute>
+				<disablequality>Catlike Reflexes</disablequality>
 			</bonus>
 		</cyberware>
 		<cyberware>
@@ -113,9 +115,10 @@ An implanted Commlink or Cyberdeck cannot benefit from an Internal Router.</note
 			<skillwire precedence="0">Rating * 2</skillwire>
 			<sociallimit>-Rating</sociallimit>
 			<specificattribute>
-			<name>REA</name>
-			<val>Rating</val>
+				<name>REA</name>
+				<val>Rating</val>
 			</specificattribute>
+			<disablequality>Catlike Reflexes</disablequality>
 		</bonus>
 		<minrating>1</minrating>
 		<rating>3</rating>

--- a/customdata/4th Place Amends/custom_bioware.xml
+++ b/customdata/4th Place Amends/custom_bioware.xml
@@ -212,18 +212,9 @@
 			<forcegrade>None</forcegrade>
 			<isgeneware />
 			<bonus>
-				<specificattribute>
-					<name>AGI</name>
-					<val>1</val>
-				</specificattribute>
-				<specificattribute>
-					<name>REA</name>
-					<val>1</val>
-				</specificattribute>
-				<specificskill>
-					<name>Gymnastics</name>
-					<bonus>2</bonus>
-				</specificskill>
+				<addqualities>
+					<addquality>Catlike Reflexes</addquality>
+				</addqualities>
 			</bonus>
 			<notes>Manually add the relevant metagenetic negative quality by taking one of the SURGE qualities for free, adding the negative quality, and then removing the SURGE quality.</notes>
 			<forcegrade>None</forcegrade>

--- a/customdata/4th Place Amends/custom_cyberware.xml
+++ b/customdata/4th Place Amends/custom_cyberware.xml
@@ -1529,6 +1529,7 @@
 					<bonus>FixedValues(-3,-4)</bonus>
 				</skilllinkedattribute>
 				<sociallimit>FixedValues(-3,-4)</sociallimit>
+				<disablequality>Catlike Reflexes</disablequality>
 			</bonus>
 			<minrating>1</minrating>
 			<rating>2</rating>

--- a/customdata/4th Place Amends/custom_qualities.xml
+++ b/customdata/4th Place Amends/custom_qualities.xml
@@ -2741,9 +2741,31 @@
 					  </skill>
 				</allof>
 			</required>
-
-			<source>SG</source>
-			<page>153</page>
+			<source>4PR</source>
+			<page>1</page>
+		</quality>
+		<quality>
+			<id>efd26062-5488-432b-a633-69e5429f00a8</id>
+			<name>Catlike Reflexes</name>
+			<karma>0</karma>
+			<category>Positive</category>
+			<hide />
+			<bonus>
+				<specificattribute>
+					<name>AGI</name>
+					<val>1</val>
+				</specificattribute>
+				<specificattribute>
+					<name>REA</name>
+					<val>1</val>
+				</specificattribute>
+				<specificskill>
+					<name>Gymnastics</name>
+					<bonus>2</bonus>
+				</specificskill>
+			</bonus>
+			<source>4PR</source>
+			<page>1</page>
 		</quality>
 	</qualities>
 </chummer>


### PR DESCRIPTION
Reaction-boosting ware suppresses Catlike Reflexes bonuses.